### PR TITLE
blip.strongloop.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ https://github.com/ValveSoftware/steam-for-linux/issues/3671
 https://github.com/nodejs/node/pull/4765
 
 https://github.com/twitter/scrooge/issues/222
+
+https://github.com/strongloop/loopback/issues/1079


### PR DESCRIPTION
tl;dr IBM used npm to track version usage metrics
everyone is quite civil on the issue but it was dramatic enough to elicit a blog response from IBM
love this repo btw cheers
