### PR TITLE
Fabric 1.x Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ https://github.com/django/django/pull/2692
 
 https://github.com/docker/docker/pull/31075
 
+https://github.com/fabric/fabric/issues/1424
+
 https://github.com/irungentoo/toxcore/issues/1227
 
 https://github.com/jashkenas/underscore/issues/1805


### PR DESCRIPTION
Took about 3 years for a private 2.x branch to be made public.