### PR TITLE
Add Valve "catbot" VAC bans

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ palantir/tslint
 
 [ValveSoftware/steam-for-linux/issues/3671](https://github.com/ValveSoftware/steam-for-linux/issues/3671)
 
+[ValveSoftware/Source-1-Games/issues/2475](https://github.com/ValveSoftware/Source-1-Games/issues/2475)
+
 [vimeo/player.js/issues/28](https://github.com/vimeo/player.js/issues/28)
 
 [NixOS/nixpkgs/issues/4952](https://github.com/NixOS/nixpkgs/issues/4952)


### PR DESCRIPTION
Related 
https://www.pcgamer.com/valve-is-handing-out-tf2-vac-bans-to-linux-users-with-catbot-in-their-usernames/
https://np.reddit.com/r/linux_gaming/comments/7ndjdt/valve_will_vac_ban_you_automatically_for_having/ds2dulw/