### PR TITLE
add https://github.com/oerdnj/deb.sury.org/issues/1768

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ lerna/lerna
 
 [npm/npm/issues/19883](https://github.com/npm/npm/issues/19883)
 
+oerdnj/deb.sury.org
+* [oerdnj/deb.sury.org/issues/1768](https://github.com/oerdnj/deb.sury.org/issues/1768#issuecomment-1258453586)
+* [archive.ph](https://archive.ph/krkTc)
+* [archive.org](http://web.archive.org/web/20220926233722/https://github.com/oerdnj/deb.sury.org/issues/1768)
+
 [opal/opal/issues/941](https://github.com/opal/opal/issues/941)
 
 [opencart/opencart/issues/1269](https://web.archive.org/web/20160120150725/https://github.com/opencart/opencart/issues/1269)

--- a/README.md
+++ b/README.md
@@ -168,9 +168,8 @@ lerna/lerna
 [npm/npm/issues/19883](https://github.com/npm/npm/issues/19883)
 
 oerdnj/deb.sury.org
-* [oerdnj/deb.sury.org/issues/1768](https://github.com/oerdnj/deb.sury.org/issues/1768#issuecomment-1258453586)
-* [archive.ph](https://archive.ph/krkTc)
-* [archive.org](http://web.archive.org/web/20220926233722/https://github.com/oerdnj/deb.sury.org/issues/1768)
+* [archive.ph](https://archive.ph/ylh6j)
+* [archive.org](https://web.archive.org/web/20220928005729/https://github.com/oerdnj/deb.sury.org/issues/1768)
 
 [opal/opal/issues/941](https://github.com/opal/opal/issues/941)
 


### PR DESCRIPTION
The owners of the deb.sury.org repository, the maintainers of the PHP packages for Debian and Ubuntu, turned out to be hostile to IPv6 users who wanted to get the PHP packages. The owners still don't know how to configure a proper DNS record in the current year and plan to blocklist the IPv6 users trying to use their PHP packages, making it inconvenient for many IPv6 users to get PHP packages for Debian and Ubuntu.