### PR TITLE
Add PolyMc hostile takeover [In Progress]

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ palantir/tslint
 
 [PiotrGrochowski/Consolas/issues/1](https://github.com/PiotrGrochowski/Consolas/issues/1)
 
+[PolyMC/PolyMC/commit/ccf2825](https://github.com/PolyMC/PolyMC/commit/ccf282593dcdbe189c99b81b8bc90cb203aed3ee)
+
 [PowerShell/PowerShell/pull/1901](https://github.com/PowerShell/PowerShell/pull/1901)
 
 [projecthamster/hamster/issues/574](https://github.com/projecthamster/hamster/issues/574)


### PR DESCRIPTION
Lenny, a maintainer of the PolyMc Minecraft launcher, did a hostile takeover of the organization. He removed all other maintainers from both the github and discord.