### PR TITLE
Add Ayojs drama

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ a good indicator that it could be included here.
 
 [atom-minimap/minimap/issues/588](https://github.com/atom-minimap/minimap/issues/588)
 
+[ayojs/ayo/issues/36](https://github.com/ayojs/ayo/issues/36) ([archive.ph](https://archive.ph/FvsR6)) ([archive.org](https://web.archive.org/web/20230120102451/https://github.com/ayojs/ayo/issues/36))
+
 [bower/bower/issues/1102](https://github.com/bower/bower/issues/1102)
 
 [bower/bower/pull/1748](https://github.com/bower/bower/pull/1748)


### PR DESCRIPTION
Add Ayojs drama.
The people leading Nodejs failed to create an inclusive and safe environment, so Ayojs was forked from Nodejs in August 2017. The developers of Ayojs, while creating an inclusive environment, were incompetent at maintaining and developing Ayojs.

https://github.com/ayojs/ayo/issues/36

https://archive.ph/FvsR6

https://web.archive.org/web/20230120102451/https://github.com/ayojs/ayo/issues/36