### PR TITLE
Add github/dmca and ytdl-org/youtube-dl drama

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ a good indicator that it could be included here.
 
 [flutter/flutter/issues/11609](https://github.com/flutter/flutter/issues/11609)
 
+github/dmca
+* [pull/8122](https://github.com/github/dmca/pull/8122) ([archive.org](https://web.archive.org/web/20230129084646/https://github.com/github/dmca/pull/8122
+), [archive.ph](https://archive.ph/l1oh6))
+* [pull/8140](https://github.com/github/dmca/pull/8140) ([archive.org](https://web.archive.org/web/20230129084629/https://github.com/github/dmca/pull/8140), [archive.ph](https://archive.ph/GrpDZ))
+
 [golang/go/issues/21956](https://github.com/golang/go/issues/21956)
 
 [golang/go/issues/33021](https://github.com/golang/go/issues/33021)


### PR DESCRIPTION
Add github/dmca and ytdl-org/youtube-dl drama:

GitHub, a docile hosting service with headquarters in the US, complied with US laws such as the DMCA and blocked the source code of "ytdl-org/youtube-dl" in October 2020. A GitHub user named "JaxTheWolf" opened a pull request to replace the entire DMCA notice from the Recording Industry Association of America with a "no" on October 25, 2020.

Sources and archives:

https://github.com/github/dmca/pull/8122
https://web.archive.org/web/20230129084646/https://github.com/github/dmca/pull/8122
https://archive.ph/l1oh6

https://github.com/github/dmca/pull/8140
https://web.archive.org/web/20230129084629/https://github.com/github/dmca/pull/8140
https://archive.ph/GrpDZ
