### PR TITLE
Add rubocop drama

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ palantir/tslint
 
 [rollup/rollup/issues/2716](https://github.com/rollup/rollup/issues/2716)
 
+[rubocop/rubocop/issues/8091](https://github.com/rubocop/rubocop/issues/8091) ([archive.org](https://web.archive.org/web/20230129101026/https://github.com/rubocop/rubocop/issues/8091), [archive.ph](https://archive.ph/3JwN5))
+
 [spring-projects/spring-hateoas/issues/66](https://github.com/spring-projects/spring-hateoas/issues/66)
 
 [standard/standard/issues/1381](https://github.com/standard/standard/issues/1381)


### PR DESCRIPTION
Add rubocop drama:

"rubocop" is a Ruby static code analyzer and formatter based on the community Ruby style guide. A GitHub user named "gcentauri" opened an issue stating that he felt uncomfortable with the word "cop" in June 2020. Another GitHub user named "veganstraightedge" forked rubocop in June 2020 and renamed the repository ruby_lint.

Primary sources and archives:

https://github.com/rubocop/rubocop/issues/8091

https://web.archive.org/web/20230129101026/https://github.com/rubocop/rubocop/issues/8091

https://archive.ph/3JwN5