### PR TITLE
New Fish-shell drama by Rustacean: Ridiculousfish

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ a good indicator that it could be included here.
 
 [facebook/react/issues/10191](https://github.com/facebook/react/issues/10191)
 
-[fish-shell/fish-shell/pull/9512](https://github.com/fish-shell/fish-shell/pull/9512) Rust Evangelism and Carcinization of Fish
+[fish-shell/fish-shell/pull/9512](https://github.com/fish-shell/fish-shell/pull/9512) Rust Evangelism and Fish Carcinisation - The Inevitable Evolution
 * Archives: [archive.org](https://web.archive.org/web/20230131091922/https://github.com/fish-shell/fish-shell/pull/9512), [archive.ph](https://archive.ph/j5Y3q)
 * Journalism: [Hacker News](https://news.ycombinator.com/item?id=34588340), [Lobste.rs](https://lobste.rs/s/fdcpy3), [4chan](https://boards.4channel.org/g/thread/91238463), [Desuarchive](https://desuarchive.org/g/thread/91238463)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ a good indicator that it could be included here.
 
 [facebook/react/issues/10191](https://github.com/facebook/react/issues/10191)
 
-[fish-shell/fish-shell/pull/9512](https://github.com/fish-shell/fish-shell/pull/9512) ([archive.org](https://web.archive.org/web/20230131070907/https://github.com/fish-shell/fish-shell/pull/9512), [archive.ph](https://archive.ph/j5Y3q))
+[fish-shell/fish-shell/pull/9512](https://github.com/fish-shell/fish-shell/pull/9512) Rust Evangelism and Carcinization of Fish
+* Archives: [archive.org](https://web.archive.org/web/20230131091922/https://github.com/fish-shell/fish-shell/pull/9512), [archive.ph](https://archive.ph/j5Y3q)
+* Journalism: [Hacker News](https://news.ycombinator.com/item?id=34588340), [Lobste.rs](https://lobste.rs/s/fdcpy3), [4chan](https://boards.4channel.org/g/thread/91238463), [Desuarchive](https://desuarchive.org/g/thread/91238463)
 
 [flathub/flathub/pull/1978](https://github.com/flathub/flathub/pull/1978)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ a good indicator that it could be included here.
 
 [facebook/react/issues/10191](https://github.com/facebook/react/issues/10191)
 
+[fish-shell/fish-shell/pull/9512](https://github.com/fish-shell/fish-shell/pull/9512) ([archive.org](https://web.archive.org/web/20230131070907/https://github.com/fish-shell/fish-shell/pull/9512), [archive.ph](https://archive.ph/j5Y3q))
+
 [flathub/flathub/pull/1978](https://github.com/flathub/flathub/pull/1978)
 
 [flutter/flutter/issues/11609](https://github.com/flutter/flutter/issues/11609)


### PR DESCRIPTION
New Fish-shell drama by Rustacean: Ridiculousfish

Fish-shell is a user-friendly command line shell for Linux, macOS, and the rest of the family. A GitHub user named Ridiculousfish is a member of the Fish-shell organization and an Apple software engineer. 

Ridiculousfish opened a pull request titled "Rewrite it in Rust" in January 2023, the URL of which was shared on Y Combinator Hacker News and prompted numerous off-topic comments from Rust missionaries and Rustaceans who knew nothing about Fish-shell.

Primary sources and web archives:

https://github.com/fish-shell/fish-shell/pull/9512
https://web.archive.org/web/20230131070907/https://github.com/fish-shell/fish-shell/pull/9512
https://archive.ph/j5Y3q
