### PR TITLE
Add `pkgxdev/pantry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ palantir/tslint
 
 [PiotrGrochowski/Consolas/issues/1](https://github.com/PiotrGrochowski/Consolas/issues/1)
 
+[pkgxdev/pantry](https://github.com/pkgxdev/pantry/issues/5358)
 
 [PolyMC/PolyMC/commit/ccf2825](https://github.com/PolyMC/PolyMC/commit/ccf282593dcdbe189c99b81b8bc90cb203aed3ee)
 


### PR DESCRIPTION
Apparently some (most?) packages on pkgxdev have AI generated descriptions

https://github.com/pkgxdev/pantry/issues/5358

https://web.archive.org/web/20240225132932/https://github.com/pkgxdev/pantry/issues/5358