### PR TITLE
Add Moq sponsor/data breach drama

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ lerna/lerna
 
 [moment/moment/issues/1407](https://github.com/moment/moment/issues/1407)
 
+[moq/issues/1372](https://github.com/devlooped/moq/issues/1372)
+
 [moxystudio/node-cross-spawn/pull/102](https://github.com/moxystudio/node-cross-spawn/pull/102)
 
 [mozilla/addon-sdk/commit/169a05b9764674b6ad3fb1c6ea1cbf3c7edf8db0#commitcomment-14824459](https://github.com/mozilla/addon-sdk/commit/169a05b9764674b6ad3fb1c6ea1cbf3c7edf8db0#commitcomment-14824459)


### PR DESCRIPTION
One of the core devs released a new version where he put in a checker if someone is sponsering moq.

For it he grabs the email saved in git config and send it to one of his servers.
This happened without consent of the other maintainer (also some core maintainer) and also without the consent of the developer building/running a project with moq in the tests.

Cherry on top: If you didn't sponsor `Moq` you got a warning in your IDE and also your build or test was slowed down by 3 seconds or something.